### PR TITLE
Adicionado observaçào para distribuições diferentes do Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,15 @@ echo \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 ```
 
+> OBSERVAÇÃO: Se você estiver usando uma distribuição diferente do Ubuntu, substitua os endereços acima respectivamente:
+> Exemplo: Instalando o docker-engine no Debian:
+> ```
+> curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+> echo \
+> "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+> $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+> ```
+
 Instale o Docker Engine
 
 ```


### PR DESCRIPTION
Se a distribuição do linux seja uma diferente do ubuntu, o endereço para adicionar a chave gpg e para adicionar à lista de repositórios do apt-get tem que ser diferente