### PR TITLE
fix: changed default max memory used by WSL 2 to 50% of host RAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Podemos dizer que o WSL 2 tem acesso quase que total ao recursos de sua máquina
 
 * A todo disco rígido.
 * A usar completamente os recursos de processamento.
-* A usar 80% da memória RAM disponível.
+* A usar 50% da memória RAM disponível.
 * A usar 25% da memória disponível para SWAP.
 
 Isto pode não ser interessante, uma vez que o WSL 2 pode usar praticamente todos os recursos de sua máquina, mas podemos configurar limites.


### PR DESCRIPTION
According to https://learn.microsoft.com/en-us/windows/wsl/wsl-config#main-wsl-settings the default max memory of WSL 2 is 50% of total RAM, instead of 80%.